### PR TITLE
Fix typo

### DIFF
--- a/jst-mode.el
+++ b/jst-mode.el
@@ -239,7 +239,7 @@ Sorry for my poor English. Help me improve the words and grammar."
       (unless key (throw 'found-it (jst-complete-project-info table)))
       (and table (jst-query-project-key table key)))))
 
-(defun jst-query-testing-framework (name &optionals key)
+(defun jst-query-testing-framework (name &optional key)
   "Query testing framework with a NAME and optional KEY."
   (catch 'found-it
     (let ((table (if (hash-table-p name) name


### PR DESCRIPTION
@cheunghy This package has some other problems.
-  Load `subr-x` for using `hash-table-keys` and `hash-table-values` however `subr-x.el` was introduced at Emacs 24.4
- Arguments number of some function calls are wrong.
- Some functions are not defined.
  - `root-dir`
  - `jst-complete-testing-framework-info`
    etc

You can know them by byte-compiling. Please check problems and fix them as possible.
Log is here.

```
In jst-complete-project-info:
jst-mode.el:273:19:Warning: jst-hashkey called with 1 argument, but requires 2

In jst-current-testing-framework:
jst-mode.el:626:4:Warning: jst-query-testing-framework called with 1 argument,
    but requires 3
jst-mode.el:756:13:Warning: reference to free variable
    `jst-verifiable-command-map'
jst-mode.el:758:13:Warning: reference to free variable `jst-command-map'

In end of data:
jst-mode.el:820:1:Warning: the following functions are not known to be defined:
    jst-complete-testing-framework-info, hash-table-keys,
    hash-table-values, root-dir
```
